### PR TITLE
Bruk npm ci i stedet for npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE_PREFIX}node as node-builder
 ADD / /source
 ENV CI=true
 WORKDIR /source
-RUN npm install && npm run build
+RUN npm ci && npm run build
 
 
 FROM docker.adeo.no:5000/pus/decorator


### PR DESCRIPTION
- npm ci baserer seg på package-lock.json og er derfor deterministisk
- npm ci gjør en sjekk på om package-lock.json er korrekt basert på hva som ligger i package.json
- Bedre ytelse