### PR TITLE
[KAIZEN-0] - Legger til metrikk for sidevisning

### DIFF
--- a/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/info-for-ikke-arbeidssoker-uten-oppfolging.tsx
+++ b/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/info-for-ikke-arbeidssoker-uten-oppfolging.tsx
@@ -1,31 +1,44 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import { Normaltekst } from 'nav-frontend-typografi';
 import Veilederpanel from 'nav-frontend-veilederpanel';
+import { AppState } from '../../reducer';
+import { uniLogger } from '../../metrikker/uni-logger';
 
 import utropstegnSvg from '../fullfor/utropstegn.svg';
 import './info-for-ikke-arbeidssoker-uten-oppfolging.less';
 
-class InfoForIkkeArbeidssokerUtenOppfolging extends React.Component {
-    render() {
-        return (
-            <div className="info-for-ikke-arbeidssoker">
-                <Veilederpanel
-                    type="plakat"
-                    svg={<img
-                        src={utropstegnSvg}
-                        alt="Informasjon"
-                        className="nav-veilederpanel__illustrasjon"
-                    />}
-                    kompakt={true}
-                >
-                    <Normaltekst>
-                        <FormattedMessage id="info-for-ikke-arbeidssoker-uten-oppfolging-innhold"/>
-                    </Normaltekst>
-                </Veilederpanel>
-            </div>
-        );
-    }
+interface StateProps {
+    state: AppState;
 }
 
-export default InfoForIkkeArbeidssokerUtenOppfolging;
+const InfoForIkkeArbeidssokerUtenOppfolging = ({ state } : StateProps) => {
+    const formidlingsgruppe = state.registreringStatus.data.formidlingsgruppe;
+    const servicegruppe = state.registreringStatus.data.servicegruppe;
+    const geografiskTilknytning = state.registreringStatus.data.geografiskTilknytning;
+    uniLogger('registrering.info-for-ikke-arbeidssoker-uten-oppfolging.sidevisning', { formidlingsgruppe, servicegruppe, geografiskTilknytning })
+    return (
+        <div className="info-for-ikke-arbeidssoker">
+            <Veilederpanel
+                type="plakat"
+                svg={<img
+                    src={utropstegnSvg}
+                    alt="Informasjon"
+                    className="nav-veilederpanel__illustrasjon"
+                />}
+                kompakt={true}
+            >
+                <Normaltekst>
+                    <FormattedMessage id="info-for-ikke-arbeidssoker-uten-oppfolging-innhold"/>
+                </Normaltekst>
+            </Veilederpanel>
+        </div>
+    );
+}
+
+const mapStateToProps = (state: AppState): StateProps => ({
+    state
+});
+
+export default connect(mapStateToProps)(InfoForIkkeArbeidssokerUtenOppfolging);


### PR DESCRIPTION
Teller antall visninger av info-for-ikke-arbeidssoker-uten-oppfolging og tar med formidlingsgruppe, servicegruppe og geografisk tilknytning