### PR TITLE
Endrer tekststørrelse på knapper for mindre skjermstørrelser

### DIFF
--- a/src/sider/registrert/aksjonspanel/registrert-aksjonspanel.less
+++ b/src/sider/registrert/aksjonspanel/registrert-aksjonspanel.less
@@ -67,6 +67,12 @@
 	}
 }
 
+@media (max-width: 375px) {
+	.registrert__lenke.knapp {
+		font-size: 0.9em;
+	}
+}
+
 @media (min-width: @screen-sm-min) {
 	.registrert {
 		&__aksjonspanel {


### PR DESCRIPTION
For noen mobiltelefonstørrelser går teksten på den ene knappen utenfor selve knappen. Gjør teksten på begge knappene litt mindre (slik at den andre ikke virker mer viktig)