### PR TITLE
Peker /dittnav til gcp i testmiljøene

### DIFF
--- a/nais/vars-q0-sbs.yaml
+++ b/nais/vars-q0-sbs.yaml
@@ -3,7 +3,7 @@ app_environment_name: q0
 appres_cms_url: https://appres-q0.nav.no
 loginservice_url: https://loginservice-q.nav.no
 arbeidssokerregistrering_url: https://arbeidssokerregistrering-q.nav.no/
-dittnav_link_url: https://tjenester-q0.nav.no/dittnav/
+dittnav_link_url: https://www.dev.nav.no/person/dittnav
 veientilarbeid_url: https://veientilarbeid-q.nav.no
 sykefravaer_url: https://tjenester-q0.nav.no/sykefravaer
 aktivitetsplan_url: https://aktivitetsplan-q.nav.no

--- a/nais/vars-q1-sbs.yaml
+++ b/nais/vars-q1-sbs.yaml
@@ -3,7 +3,7 @@ app_environment_name: q1
 appres_cms_url: https://appres-q1.nav.no
 loginservice_url: https://loginservice-q.nav.no
 arbeidssokerregistrering_url: https://arbeidssokerregistrering-q1.nav.no
-dittnav_link_url: https://tjenester-q1.nav.no/dittnav/
+dittnav_link_url: https://www.dev.nav.no/person/dittnav
 veientilarbeid_url: https://veientilarbeid-q1.nav.no
 sykefravaer_url: https://tjenester-q1.nav.no/sykefravaer
 aktivitetsplan_url: https://aktivitetsplan-q1.dev-sbs.nais.io


### PR DESCRIPTION
dittnav er ikke lenger tilgjengelig i q-miljøene så da peker vi i stedet til dev.nav