### PR TITLE
Visuell fiks etter oppdatering av veilederpanel

### DIFF
--- a/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/info-for-ikke-arbeidssoker-uten-oppfolging.less
+++ b/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/info-for-ikke-arbeidssoker-uten-oppfolging.less
@@ -17,24 +17,11 @@
 
 .info-for-ikke-arbeidssoker {
   padding-top: 3rem;
-
-  .nav-veilederpanel {
-    margin: 5rem 1rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-
-    .nav-veileder__frame img,
-    .nav-veileder__frame svg {
-      height: 100%;
-    }
-  }
 }
 
 @media (min-width: @screen-sm-min) {
   .info-for-ikke-arbeidssoker {
-    .nav-veilederpanel {
-      max-width: 630px;
-      margin: 6rem auto 0 auto;
-    }
+    max-width: 630px;
+    margin: 6rem auto 0 auto;
   }
 }

--- a/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/melding.tsx
+++ b/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/melding.tsx
@@ -95,7 +95,7 @@ class Melding extends React.Component<BaseProps, OptionState> {
 
     return (
       <div className="info-for-ikke-arbeidssoker">
-        <Panel border className="nav-veilederpanel">
+        <Panel border>
           <Alertstripe type="info" className="blokk-s">
             Du er ikke registrert som arbeidssøker. Vi må hjelpe deg videre i andre kanaler.
           </Alertstripe>


### PR DESCRIPTION
Nye versjon av veilederpanel og style førte til at ene feilsiden brakk.
Oppdatering består i å fjerne en del kode som overstyrte default.