### PR TITLE
Amplitude oppdateringer

### DIFF
--- a/src/sider/allerede-registrert/allerede-registrert.tsx
+++ b/src/sider/allerede-registrert/allerede-registrert.tsx
@@ -67,7 +67,7 @@ class AlleredeRegistrert extends React.Component<Props> {
     const geografiskTilknytning = this.props.state.registreringStatus.data.geografiskTilknytning || "INGEN_VERDI";
     const rettighetsgruppe = this.props.state.registreringStatus.data.rettighetsgruppe;
     const isIARBS = formidlingsgruppeOrIngenVerdi === "IARBS";
-    uniLogger("registrering.visning", {
+    uniLogger("arbeidssokerregistrering.visning", {
       viser: "Viser allerede registrert siden",
       formidlingsgruppe,
       servicegruppe,

--- a/src/sider/allerede-registrert/allerede-registrert.tsx
+++ b/src/sider/allerede-registrert/allerede-registrert.tsx
@@ -21,7 +21,8 @@ class AlleredeRegistrert extends React.Component<Props> {
     const servicegruppe = event.currentTarget.dataset.servicegruppe;
     const geografiskTilknytning = event.currentTarget.dataset.geografisktilknytning;
     const rettighetsgruppe = event.currentTarget.dataset.rettighetsgruppe;
-    uniLogger("registrering.allerede-registrert.click.aktivitetsplan", {
+    uniLogger("registrering.aktivitet", {
+      aktivitet: "Går til aktivitetsplanen fra allerede registrert siden",
       formidlingsgruppe,
       servicegruppe,
       geografiskTilknytning,

--- a/src/sider/allerede-registrert/allerede-registrert.tsx
+++ b/src/sider/allerede-registrert/allerede-registrert.tsx
@@ -35,7 +35,8 @@ class AlleredeRegistrert extends React.Component<Props> {
     const servicegruppe = event.currentTarget.dataset.servicegruppe;
     const geografiskTilknytning = event.currentTarget.dataset.geografisktilknytning;
     const rettighetsgruppe = event.currentTarget.dataset.rettighetsgruppe;
-    uniLogger("registrering.allerede-registrert.click.veienTilArbeid", {
+    uniLogger("registrering.aktivitet", {
+      aktivitet: "Går til veien til arbeid fra allerede registrert siden",
       formidlingsgruppe,
       servicegruppe,
       geografiskTilknytning,
@@ -48,7 +49,8 @@ class AlleredeRegistrert extends React.Component<Props> {
     const servicegruppe = event.currentTarget.dataset.servicegruppe;
     const geografiskTilknytning = event.currentTarget.dataset.geografisktilknytning;
     const rettighetsgruppe = event.currentTarget.dataset.rettighetsgruppe;
-    uniLogger("registrering.allerede-registrert.click.dialog", {
+    uniLogger("registrering.aktivitet", {
+      aktivitet: "Går til dialogen fra allerede registrert siden",
       formidlingsgruppe,
       servicegruppe,
       geografiskTilknytning,
@@ -65,7 +67,8 @@ class AlleredeRegistrert extends React.Component<Props> {
     const geografiskTilknytning = this.props.state.registreringStatus.data.geografiskTilknytning || "INGEN_VERDI";
     const rettighetsgruppe = this.props.state.registreringStatus.data.rettighetsgruppe;
     const isIARBS = formidlingsgruppeOrIngenVerdi === "IARBS";
-    uniLogger("registrering.allerede-registrert.sidevisning", {
+    uniLogger("registrering.visning", {
+      viser: "Viser allerede registrert siden",
       formidlingsgruppe,
       servicegruppe,
       geografiskTilknytning,

--- a/src/sider/allerede-registrert/iarbs-melding.tsx
+++ b/src/sider/allerede-registrert/iarbs-melding.tsx
@@ -109,7 +109,7 @@ const Melding = ({ state }: Props) => {
                   eller ring oss på <strong>55 55 33 33</strong>.
                 </Normaltekst>
                 <Radio
-                  label={"Jeg vil opprette CV eller jobbprofil"}
+                  label={"Jeg vil opprette CV eller jobbønsker"}
                   name="kontaktmeg"
                   id="cv"
                   onChange={handleClickContact}
@@ -124,7 +124,7 @@ const Melding = ({ state }: Props) => {
                   >
                     Gå til Arbeidsplassen.no
                   </a>{" "}
-                  for å opprette CV og jobbprofil.
+                  for å opprette CV og jobbønsker.
                 </Normaltekst>
                 <Radio
                   label={"Jeg finner ikke det jeg leter etter"}

--- a/src/sider/allerede-registrert/iarbs-melding.tsx
+++ b/src/sider/allerede-registrert/iarbs-melding.tsx
@@ -23,7 +23,8 @@ const Melding = ({ state }: Props) => {
   };
 
   const handleClickDialog = () => {
-    uniLogger("registrering.allerede-registrert.click.dialog", {
+    uniLogger("registrering.aktivitet", {
+      aktivitet: "Går til dialogen fra iarbs-melding",
       formidlingsgruppe,
       servicegruppe,
       geografiskTilknytning,
@@ -48,7 +49,8 @@ const Melding = ({ state }: Props) => {
         rettighetsgruppe,
       });
     } else if (hensikt === "arbeidsplassen") {
-      uniLogger("registrering.allerede-registrert.click.arbeidsplassen", {
+      uniLogger("registrering.aktivitet", {
+        aktivitet: "Går til arbeidsplassen fra iarbs-melding",
         formidlingsgruppe,
         servicegruppe,
         geografiskTilknytning,

--- a/src/sider/allerede-registrert/iarbs-melding.tsx
+++ b/src/sider/allerede-registrert/iarbs-melding.tsx
@@ -41,7 +41,8 @@ const Melding = ({ state }: Props) => {
       result.className = "show-result-text";
     }
     if (hensikt !== "arbeidsplassen") {
-      uniLogger("registrering.allerede-registrert.hensikt.click", {
+      uniLogger("arbeidssokerregistrering.aktivitet", {
+        aktivitet: "Velger hensikt fra iarbs-melding",
         hensikt,
         formidlingsgruppe,
         servicegruppe,
@@ -49,7 +50,7 @@ const Melding = ({ state }: Props) => {
         rettighetsgruppe,
       });
     } else if (hensikt === "arbeidsplassen") {
-      uniLogger("registrering.aktivitet", {
+      uniLogger("arbeidssokerregistrering.aktivitet", {
         aktivitet: "Går til arbeidsplassen fra iarbs-melding",
         formidlingsgruppe,
         servicegruppe,

--- a/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/info-for-ikke-arbeidssoker-uten-oppfolging.tsx
+++ b/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/info-for-ikke-arbeidssoker-uten-oppfolging.tsx
@@ -23,7 +23,7 @@ class InfoForIkkeArbeidssokerUtenOppfolging extends React.Component<StateProps> 
     const maksdato = this.props.state.registreringStatus.data.maksDato;
     const dagerTilMaksdato = maksdato ? antallDagerTilMaksdato(new Date(), new Date(maksdato)).toString() : "null";
 
-    uniLogger("registrering.visning", {
+    uniLogger("arbeidssokerregistrering.visning", {
       viser: "Viser info for ikke arbeidssoker uten oppfolging",
       formidlingsgruppe,
       servicegruppe,

--- a/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/info-for-ikke-arbeidssoker-uten-oppfolging.tsx
+++ b/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/info-for-ikke-arbeidssoker-uten-oppfolging.tsx
@@ -23,7 +23,8 @@ class InfoForIkkeArbeidssokerUtenOppfolging extends React.Component<StateProps> 
     const maksdato = this.props.state.registreringStatus.data.maksDato;
     const dagerTilMaksdato = maksdato ? antallDagerTilMaksdato(new Date(), new Date(maksdato)).toString() : "null";
 
-    uniLogger("registrering.info-for-ikke-arbeidssoker-uten-oppfolging.sidevisning", {
+    uniLogger("registrering.visning", {
+      viser: "Viser info for ikke arbeidssoker uten oppfolging",
       formidlingsgruppe,
       servicegruppe,
       geografiskTilknytning,

--- a/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/melding.tsx
+++ b/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/melding.tsx
@@ -64,7 +64,7 @@ class Melding extends React.Component<BaseProps, OptionState> {
       const id = event.target.id;
       const numberOfChoices = this.increaseOptions();
       const choices = this.addChoice(id).join(", ");
-      uniLogger("registrering.aktivitet", {
+      uniLogger("arbeidssokerregistrering.aktivitet", {
         aktivitet: "Velger alternativ fra info for ikke arbeidssøker siden",
         formidlingsgruppe,
         servicegruppe,

--- a/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/melding.tsx
+++ b/src/sider/info-for-ikke-arbeidssoker-uten-oppfolging/melding.tsx
@@ -62,11 +62,10 @@ class Melding extends React.Component<BaseProps, OptionState> {
 
     const handleClickLog = (event) => {
       const id = event.target.id;
-      const metricName = `registrering.ikke-arbeidssoker-utenfor-oppfolging.click.${id}`;
       const numberOfChoices = this.increaseOptions();
       const choices = this.addChoice(id).join(", ");
-      uniLogger("registrering.ikke-arbeidssoker-utenfor-oppfolging.click", { numberOfChoices, choices });
-      uniLogger(metricName, {
+      uniLogger("registrering.aktivitet", {
+        aktivitet: "Velger alternativ fra info for ikke arbeidssøker siden",
         formidlingsgruppe,
         servicegruppe,
         geografiskTilknytning,

--- a/src/sider/krever-reaktivering/krever-reaktivering.tsx
+++ b/src/sider/krever-reaktivering/krever-reaktivering.tsx
@@ -46,17 +46,23 @@ class KreverReaktivering extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    uniLogger("arbeidssokerregistrering.reaktivering.sidevisning");
+    uniLogger("arbeidssokerregistrering.visning", {
+      viser: "Viser siden for reaktivering",
+    });
   }
 
   avbrytReaktiveringOnClick() {
-    uniLogger("arbeidssokerregistrering.reaktivering", { klikk: "avbryt" });
+    uniLogger("arbeidssokerregistrering.aktivitet", {
+      aktivitet: "Velger avbryt fra reaktiveringssiden",
+    });
   }
 
   reaktiverBrukerOnClick() {
     const { onReaktiverBruker, history } = this.props;
     this.setState({ reaktivererBruker: true });
-    uniLogger("arbeidssokerregistrering.reaktivering", { klikk: "reaktiver" });
+    uniLogger("arbeidssokerregistrering.aktivitet", {
+      aktivitet: "Velger reaktiver fra reaktiveringssiden",
+    });
 
     onReaktiverBruker().then((res) => {
       if (!!res) {

--- a/src/sider/registrert/registrert.tsx
+++ b/src/sider/registrert/registrert.tsx
@@ -35,7 +35,10 @@ class DuErNaRegistrert extends React.Component<AllProps> {
     const erReaktivert = registreringType === RegistreringType.REAKTIVERING;
     const hentTekstId = this.hentTekstId(erSykmeldt);
     const tittelId = erIFSS() ? "duernaregistrert-manuell-innholdstittel" : hentTekstId("innholdstittel");
-    uniLogger("arbeidssokerregistrering.success", { registreringType: registreringType });
+    uniLogger("arbeidssokerregistrering.visning", {
+      viser: "Viser kvitteringssiden",
+      registreringType: registreringType,
+    });
     return (
       <section className={cls("registrert", { erIE: erIE(), "registrert-fss": erIFSS() })}>
         <div className={cls("registrert__avsjekk", { "registrert__avsjekk-sykmeldt": erSykmeldt })}>


### PR DESCRIPTION
Endrer alle ulike former for metrikker til Amplitude fra app.side.del.click o.l. til arbeidssokerregistrering.aktivitet og arbeidssokerregistrering.visning.
Dette vil gjøre at metrikkene matcher de vi får fra "Veien til arbeid" og at det vil bli enklere å lese hva vi måler ut fra innholdet i metrikken