### PR TITLE
Sentry kun på NAV-miljø

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx tsc
+npx tsc && npm run test:ci

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "test": "craco test",
+    "test:ci": "CI=true craco test",
     "postinstall": "husky install"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cypress:clear": "cypress cache clear",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
+    "test": "craco test",
     "postinstall": "husky install"
   },
   "dependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import { erIFSS } from "./utils/fss-utils";
 import App from "./app";
 import AppFss from "./app-fss";
 import "./index.less";
+import { erNAVMiljo } from "./utils/url-utils";
 
 moment.locale("nb");
 
@@ -39,11 +40,6 @@ if (process.env.REACT_APP_MOCK) {
 }
 
 const miljo = window.location.hostname;
-const erNAVMiljo = (miljo: string) =>
-  miljo.endsWith(".nav.no") ||
-  miljo.endsWith(".adeo.no") ||
-  miljo.endsWith(".preprod.local") ||
-  miljo.endsWith(".nav.party");
 const sendFeilTilSentry = erNAVMiljo(miljo) && !erIFSS();
 Sentry.init({
   dsn: "https://52908dd3ce2a4fde8bd57bc1cd03651c@sentry.gc.nav.no/66",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,7 +39,12 @@ if (process.env.REACT_APP_MOCK) {
 }
 
 const miljo = window.location.hostname;
-const sendFeilTilSentry = !erIFSS();
+const erNAVMiljo =
+  miljo.endsWith(".nav.no") ||
+  miljo.endsWith(".adeo.no") ||
+  miljo.endsWith(".preprod.local") ||
+  miljo.endsWith(".nav.party");
+const sendFeilTilSentry = erNAVMiljo && !erIFSS();
 Sentry.init({
   dsn: "https://52908dd3ce2a4fde8bd57bc1cd03651c@sentry.gc.nav.no/66",
   environment: miljo,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,11 +38,11 @@ if (process.env.REACT_APP_MOCK) {
   require("./mocks/mocks");
 }
 
-const environment = window.location.hostname;
+const miljo = window.location.hostname;
 const sendFeilTilSentry = !erIFSS();
 Sentry.init({
   dsn: "https://52908dd3ce2a4fde8bd57bc1cd03651c@sentry.gc.nav.no/66",
-  environment,
+  environment: miljo,
   enabled: sendFeilTilSentry,
   autoSessionTracking: false,
   ignoreErrors: [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,23 +38,22 @@ if (process.env.REACT_APP_MOCK) {
   require("./mocks/mocks");
 }
 
-if (!erIFSS()) {
-  const environment = window.location.hostname;
-  Sentry.init({
-    dsn: "https://52908dd3ce2a4fde8bd57bc1cd03651c@sentry.gc.nav.no/66",
-    environment,
-    autoSessionTracking: false,
-    ignoreErrors: [
-      "TypeError: Failed to fetch",
-      "TypeError: NetworkError when attempting to fetch resource.",
-      "TypeError: cancelled",
-      "TypeError: avbrutt",
-      "TypeError: cancelado",
-      "TypeError: anulowane",
-      "TypeError: avbruten",
-      "TypeError: anulat",
-    ],
-  });
-}
+const environment = window.location.hostname;
+Sentry.init({
+  dsn: "https://52908dd3ce2a4fde8bd57bc1cd03651c@sentry.gc.nav.no/66",
+  environment,
+  enabled: !erIFSS(),
+  autoSessionTracking: false,
+  ignoreErrors: [
+    "TypeError: Failed to fetch",
+    "TypeError: NetworkError when attempting to fetch resource.",
+    "TypeError: cancelled",
+    "TypeError: avbrutt",
+    "TypeError: cancelado",
+    "TypeError: anulowane",
+    "TypeError: avbruten",
+    "TypeError: anulat",
+  ],
+});
 
 ReactDOM.render(erIFSS() ? <AppFss /> : <App />, document.getElementById("root") as HTMLElement);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,12 +39,12 @@ if (process.env.REACT_APP_MOCK) {
 }
 
 const miljo = window.location.hostname;
-const erNAVMiljo =
+const erNAVMiljo = (miljo: string) =>
   miljo.endsWith(".nav.no") ||
   miljo.endsWith(".adeo.no") ||
   miljo.endsWith(".preprod.local") ||
   miljo.endsWith(".nav.party");
-const sendFeilTilSentry = erNAVMiljo && !erIFSS();
+const sendFeilTilSentry = erNAVMiljo(miljo) && !erIFSS();
 Sentry.init({
   dsn: "https://52908dd3ce2a4fde8bd57bc1cd03651c@sentry.gc.nav.no/66",
   environment: miljo,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,10 +39,11 @@ if (process.env.REACT_APP_MOCK) {
 }
 
 const environment = window.location.hostname;
+const sendFeilTilSentry = !erIFSS();
 Sentry.init({
   dsn: "https://52908dd3ce2a4fde8bd57bc1cd03651c@sentry.gc.nav.no/66",
   environment,
-  enabled: !erIFSS(),
+  enabled: sendFeilTilSentry,
   autoSessionTracking: false,
   ignoreErrors: [
     "TypeError: Failed to fetch",

--- a/src/utils/url-utils.test.ts
+++ b/src/utils/url-utils.test.ts
@@ -1,0 +1,33 @@
+import { erNAVMiljo } from "./url-utils";
+import { expect } from "chai";
+
+describe("url-utils", () => {
+  test("erNAVMiljo skal returnere true for sbs-miljø", () => {
+    expect(erNAVMiljo("arbeidssokerregistrering.nav.no")).to.equal(true);
+    expect(erNAVMiljo("arbeidssokerregistrering.nais.oera.no")).to.equal(true);
+    expect(erNAVMiljo("arbeidssokerregistrering.nais.oera-q.local")).to.equal(true);
+    expect(erNAVMiljo("tjenester-q1.nav.no")).to.equal(true);
+  });
+
+  test("erNAVMiljo skal returnere true for demo-miljø", () => {
+    expect(erNAVMiljo("arbeidssokerregistrering.nav.party")).to.equal(true);
+  });
+
+  test("erNAVMiljo skal returnere true for fss-miljø", () => {
+    expect(erNAVMiljo("arbeidssokerregistrering.nais.adeo.no")).to.equal(true);
+    expect(erNAVMiljo("arbeidssokerregistrering-fss.nais.adeo.no")).to.equal(true);
+    expect(erNAVMiljo("app-q1.adeo.no")).to.equal(true);
+    expect(erNAVMiljo("app.adeo.no")).to.equal(true);
+  });
+
+  test("erNAVMiljo skal returnere false for google-tjenster", () => {
+    expect(erNAVMiljo("hjksdgfjaugsweeirufgw297-ag34ufga8w7t-nav.translate.goog")).to.equal(false);
+    expect(erNAVMiljo("translate.googleusercontent.com")).to.equal(false);
+    expect(erNAVMiljo("google.com")).to.equal(false);
+  });
+
+  test("erNAVMiljo skal returnere false for nesten riktige hostnavn", () => {
+    expect(erNAVMiljo("arbeidssokerregistrering.knav.no")).to.equal(false);
+    expect(erNAVMiljo("arbeidssokerregistrering.nav.no.dk")).to.equal(false);
+  });
+});

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -19,4 +19,6 @@ export const erNAVMiljo = (miljo: string) =>
   miljo.endsWith(".nav.no") ||
   miljo.endsWith(".adeo.no") ||
   miljo.endsWith(".preprod.local") ||
+  miljo.endsWith(".oera.no") ||
+  miljo.endsWith(".oera-q.local") ||
   miljo.endsWith(".nav.party");

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -14,3 +14,9 @@ export const lagDetaljeVisningUrl = () => {
 export const erProduksjon = () => {
   return url.indexOf("arbeidssokerregistrering.nav.no") > -1;
 };
+
+export const erNAVMiljo = (miljo: string) =>
+  miljo.endsWith(".nav.no") ||
+  miljo.endsWith(".adeo.no") ||
+  miljo.endsWith(".preprod.local") ||
+  miljo.endsWith(".nav.party");


### PR DESCRIPTION
Kjører kun Sentry på NAV-miljø (sbs, fss, og litt annet), for å unngå feilrapporter fra bl.a. Google Translate-sider.

La også til enkel kjøring av ikke-cypress-tester.
**Merk** at dette kun kjøres via husky, og foreløpig ikke i GitHub actions.