### PR TITLE
Fjern moment

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,4 +1,3 @@
-import moment from "moment";
 import {alleFeatureToggles} from "../../src/ducks/feature-toggles";
 import {FEATURE_URL} from "../../src/ducks/api";
 
@@ -52,12 +51,7 @@ Cypress.Commands.add('configure', option => {
             cy.route('GET', '/pam-janzz/rest/typeahead/yrke-med-styrk08?q=Klovn', 'fixture:tidligere-yrke');
             cy.route('POST', '/veilarbregistrering/api/startregistrersykmeldt', {})
                 .as('startregistrersykemeldt');
-            cy.fixture('startregistrering/registrering-sykefravaer')
-                .then(fixture => {
-                    // Setter dato tretten uker frem i tid
-                    fixture.maksDato = moment(new Date(), 'DD.MM.YYYY').add(13, 'week');
-                    cy.route('GET', '/veilarbregistrering/api/startregistrering', fixture);
-                });
+            cy.route('GET', '/veilarbregistrering/api/startregistrering',  'fixture:/startregistrering/registrering-sykefravaer')
             break;
         case 'reaktivering':
             cy.on('window:before:load', win => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14014,7 +14014,8 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "less-plugin-npm-import": "2.1.0",
     "lodash": "4.17.21",
     "lodash.throttle": "4.1.1",
-    "moment": "2.29.1",
     "nav-frontend-alertstriper": "4.0.1",
     "nav-frontend-alertstriper-style": "3.0.1",
     "nav-frontend-chevron": "1.0.30",

--- a/src/app-fss.tsx
+++ b/src/app-fss.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import "moment/locale/nb";
 import { Provider } from "react-redux";
 import IntlProvider from "./Intl-provider";
 import { getStore } from "./store";

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import "moment/locale/nb";
 import { Provider } from "react-redux";
 import IntlProvider from "./Intl-provider";
 import { getStore } from "./store";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,15 +4,11 @@ import "idempotent-babel-polyfill";
 import "react-app-polyfill/ie11";
 import Modal from "react-modal";
 import * as Sentry from "@sentry/react";
-import moment from "moment";
-import "moment/locale/nb";
 import { erIFSS } from "./utils/fss-utils";
 import App from "./app";
 import AppFss from "./app-fss";
 import "./index.less";
 import { erNAVMiljo } from "./utils/url-utils";
-
-moment.locale("nb");
 
 Modal.setAppElement("#root");
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,3 @@
-import moment from "moment";
-
 export function hentFornavn(name: string | undefined) {
   return name ? storForbokstavOgEtterBindestrek(name.split(" ")[0]) : "";
 }
@@ -31,62 +29,6 @@ export function guid() {
 
 export interface MatchProps {
   id: string;
-}
-
-/*
- * Regn ut alder basert på fnr som kommer fra `veilarboppfolging/api/me`
- * Senere kan koden under bli erstattes med at backend regner ut alder istenfor
- * */
-
-function erDNummer(personId: string) {
-  const forsteSiffer = Number(personId.substring(0, 1));
-  return forsteSiffer > 3 && forsteSiffer < 8;
-}
-
-function parseDNummer(personId: string) {
-  return !erDNummer(personId) ? personId : personId.substring(1);
-}
-
-function toSifferFodselsAar(personId: string) {
-  return personId.substring(4, 6);
-}
-
-function hentAarhundre(personId: string) {
-  let result;
-  const individNummer = Number(personId.substring(6, 9));
-  const fodselsAar = Number(personId.substring(4, 6));
-
-  if (individNummer <= 499) {
-    result = "19";
-  } else if (individNummer >= 500 && fodselsAar < 40) {
-    result = "20";
-  } else if (individNummer >= 500 && individNummer <= 749 && fodselsAar >= 54) {
-    result = "18";
-  } else if (individNummer >= 900 && fodselsAar > 39) {
-    result = "19";
-  }
-
-  return result;
-}
-
-export function formaterDato(dato: string | undefined) {
-  if (!dato) {
-    return "";
-  }
-
-  return moment(dato, "YYYY-MM-DD").format("DD. MMMM YYYY");
-}
-
-export function hentAlder(personId: string) {
-  const fnr = parseDNummer(personId);
-
-  const aarhundre = hentAarhundre(fnr);
-  const fnrForsteFireSiffer = fnr.substring(0, 4);
-  const toSifferFAar = toSifferFodselsAar(fnr);
-
-  const fodselsdato = moment(`${fnrForsteFireSiffer}${aarhundre}${toSifferFAar}`, "DDMMYYYY");
-
-  return moment().diff(fodselsdato, "years");
 }
 
 export function scrollToBanner() {


### PR DESCRIPTION
Moment ble kun brukt i to tilfeller:
1. I utility-metoder rundt dato-håndtering
2. I tester av `maksDato`-oppførsel

Utility-metodene var ikke i bruk, så de metodene var det bare å fjerne.
Testen satt en verdi av `maksDato` som aldri kan oppstå i reelle situasjoner, ettersom den nå alltid blir satt til `null`. Dermed var det bare å fjerne den eksplisitte logikken her også.

Dette betyr at vi enkelt og greit kan fjerne moment, uten å måtte innføre nye biblioteker for å opprettholde dagens oppførsel. 🥳  Win-win.